### PR TITLE
Hot reload config and update RBAC rules

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"github.com/fsnotify/fsnotify"
 	"context"
 	"fmt"
 	"net"
@@ -77,6 +78,14 @@ func main() {
 	if configFileNotFound {
 		logger.Warn("configuration file not found", nil)
 	}
+
+	viper.WatchConfig()
+	viper.OnConfigChange(func(e fsnotify.Event) {
+		logger.Info("Config file changed: " + e.Name)
+		config = Config{}
+		err = viper.Unmarshal(&config)
+		emperror.Panic(errors.Wrap(err, "failed to unmarshal configuration"))
+	})
 
 	logger.Info("configuration info", map[string]interface{}{
 		"ClientID":   config.Tokenhandler.Dex.ClientID,


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no|
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | mentioned in #18 
| License         | Apache 2.0


### What's in this PR?
Hot reload the config file with `viper.WatchConfig()` & Update RBAC rules from ClusterRole, ClusterRolebinding & RoleBinding if exists whenever `POST /rbac` it's called


### Why?
Because the solution to this should not be to delete the `jwt-to-rbac` pod  & the RBAC objects when the config.yaml ConfigMap it's edited to be able to reload the config.

| Q               | A
| --------------- | ---
| Bug fix?        | no|
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | mentioned in #18 
| License         | Apache 2.0


### What's in this PR?
Hot reload the config file with `viper.WatchConfig()` & Update RBAC rules from ClusterRole, ClusterRolebinding & RoleBinding if exists whenever `POST /rbac` it's called


### Why?
Because the solution to this should not be to delete the `jwt-to-rbac` pod  & the RBAC objects when the config.yaml ConfigMap it's edited to be able to reload the config.

