### PR TITLE
Workflows updates, add chart publish

### DIFF
--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -1,0 +1,18 @@
+name: Create and upload chart
+on:
+  push:
+    tags:
+      - "charts/[0-9]+.[0-9]+.[0-9]+"
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: unwrittenmedia/helm3-push-action@v1.0.2
+      env:
+        SOURCE_DIR: 'charts'
+        CHART_FOLDER: 'jwt-to-rbac'
+        CHARTMUSEUM_URL: 'https://kubernetes-charts.banzaicloud.com'
+        CHARTMUSEUM_USER: '${{ secrets.CHARTMUSEUM_USER }}'
+        CHARTMUSEUM_PASSWORD: '${{ secrets.CHARTMUSEUM_PASSWORD }}'


### PR DESCRIPTION
Signed-off-by: Peter Balogh <p.balogh.sa@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    |yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #25 , related: https://github.com/banzaicloud/banzai-charts/pull/1147
| License         | Apache 2.0


### What's in this PR?
- Update workflows
- Add chart publish as GitHub action

### Additional context
Using action https://github.com/UnwrittenMedia/helm3-push-action to push helm charts, which leverages https://github.com/chartmuseum/helm-push 