### PR TITLE
feat(tokenhandler): rename dex to oidc in configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ JWT-to-RBAC is a core part of [Banzai Cloud Pipeline](https://banzaicloud.com/),
 
 There are some pre-requirements to kick this of for your own testing.
 
-* Configured Dex server which issues JWT tokens. If you want to issue tokens with Dex you have to configure it with LDAP connector. You can use the Banzai Cloud [Dex chart](https://github.com/banzaicloud/banzai-charts/tree/master/dex).
+* Configured Dex server as OIDC provider which issues JWT tokens. If you want to issue tokens with Dex you have to configure it with LDAP connector. You can use the Banzai Cloud [Dex chart](https://github.com/banzaicloud/banzai-charts/tree/master/dex).
 * GitHub account assigned for an organization or configured LDAP server - you can use the [openldap](https://github.com/osixia/docker-openldap) Docker image
 * Authentication application which uses Dex as an OpenID connector (in our case is [Pipeline](https://github.com/banzaicloud/pipeline).
 
@@ -32,7 +32,7 @@ There are some pre-requirements to kick this of for your own testing.
 
 The whole process is broken down to two main parts:
 
-* Dex auth flow
+* Dex (OIDC) auth flow
 * jwt-to-rbac ServiceAccount creation flow
 
 **Dex authentication flow:**
@@ -47,7 +47,7 @@ The whole process is broken down to two main parts:
 
 1. Authentication App has ID token (JWT)
 2. POST ID token to jwt-to-rbac App
-3. jwt-to-rbac validates ID token with Dex
+3. jwt-to-rbac validates ID token with Dex or other OIDC prvider
 4. jwt-to-rbac extracts username, groups and so on from the token
 5. jwt-to-rbac calls API server to crate `ServiceAccount`, `ClusterRoles` and `ClusterRoleBindings`
 6. jwt-to-rbac get service account token and sends it to Authentication App
@@ -195,7 +195,7 @@ log:
   noColor: true
 
 tokenhandler:
-  dex:
+  oidc:
     clientID: example-app
     issuerURL: "http://dex/dex"
 
@@ -244,7 +244,7 @@ kubectl port-forward svc/jwt-to-rbac 5555
 
 Now you can communicate with the jwt-to-rbac app.
 
-### 2. POST ID token issued by Dex to jwt-to-rbac API
+### 2. POST ID token issued by Oidc to jwt-to-rbac API
 ```shell
 curl --request POST \
   --url http://localhost:5555/rbac/ \

--- a/charts/jwt-to-rbac/Chart.yaml
+++ b/charts/jwt-to-rbac/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "0.3.0"
+appVersion: "0.4.0"
 description: A Helm chart for Kubernetes
 name: jwt-to-rbac
-version: 0.3.1
+version: 0.4.0
 home: https://github.com/banzaicloud/jwt-to-rbac
 maintainers:
 - name: BanzaiCloud

--- a/charts/jwt-to-rbac/Chart.yaml
+++ b/charts/jwt-to-rbac/Chart.yaml
@@ -1,5 +1,5 @@
-apiVersion: v1
-appVersion: "0.4.0"
+apiVersion: v2
+appVersion: 0.4.0
 description: A Helm chart for Kubernetes
 name: jwt-to-rbac
 version: 0.4.0

--- a/charts/jwt-to-rbac/README.md
+++ b/charts/jwt-to-rbac/README.md
@@ -12,12 +12,12 @@ $ helm repo update
 Deploying jwt-to-rbac:
 
 ```bash
-$ helm install --name <name> --set config.tokenhandler.dex.clientID=<client-id> --set config.tokenhandler.dex.issuerURL=<http://dex-url/dex>
+$ helm install --name <name> --set config.tokenhandler.oidc.clientID=<client-id> --set config.tokenhandler.oidc.issuerURL=<http://dex-url/dex>
 ```
 
 ## Configuration
 
-The following table lists configurable parameters of the dex chart and their default values.
+The following table lists configurable parameters of the `jwt-to-rbac` chart and their default values.
 
 |               Parameter             |                Description                  |                  Default                 |
 | ----------------------------------- | ------------------------------------------- | -----------------------------------------|
@@ -34,8 +34,8 @@ The following table lists configurable parameters of the dex chart and their def
 |config.log.level                     |jwt-to-rbac log level                        |"4"                                       |
 |config.log.format                    |jwt-to-rbac log format                       |"json"                                    |
 |config.log.noColor                   |jwt-to-rbac log noColor                      |true                                      |
-|config.tokenhandler.caCertPath       |CA cert for Dex used self-signed cert        |""                                        |
-|config.tokenhandler.dex.clientID     |client ID  for Dex                           |""                                        |
-|config.tokenhandler.dex.issuerURL    |Dex url                                      |""                                        |
+|config.tokenhandler.caCertPath       |CA cert for Oidc used self-signed cert       |""                                        |
+|config.tokenhandler.oidc.clientID    |client ID for Oidc                           |""                                        |
+|config.tokenhandler.oidc.issuerURL   |Oidc url                                     |""                                        |
 |config.rbachandler.githubOrg         |specified github organization                |""                                        |
 |config.rbachandler.customGroups      |custom group mapping, more details in [JWT-to-RBAC](https://github.com/banzaicloud/jwt-to-rbac)|[]|

--- a/charts/jwt-to-rbac/ci/test-values.yaml
+++ b/charts/jwt-to-rbac/ci/test-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/banzaicloud/jwt-to-rbac
-  tag: ""
+  tag: latest
   pullPolicy: IfNotPresent
 
 nameOverride: ""

--- a/charts/jwt-to-rbac/templates/deployment.yaml
+++ b/charts/jwt-to-rbac/templates/deployment.yaml
@@ -24,7 +24,7 @@ spec:
       serviceAccountName: {{ include "jwt-to-rbac.name" . }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           securityContext:
             runAsUser: 2

--- a/charts/jwt-to-rbac/values.yaml
+++ b/charts/jwt-to-rbac/values.yaml
@@ -32,7 +32,7 @@ config:
     noColor: true
   tokenhandler:
     caCertPath: ""
-    dex:
+    oidc:
       clientID: ""
       issuerURL: ""
   rbachandler:

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -28,7 +28,7 @@ import (
 )
 
 type Config struct {
-	// Dex configuration
+	// Oidc configuration
 	Tokenhandler tokenhandler.Config
 	// rbachandler config
 	Rbachandler rbachandler.Config

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -88,8 +88,8 @@ func main() {
 	})
 
 	logger.Info("configuration info", map[string]interface{}{
-		"ClientID":   config.Tokenhandler.Dex.ClientID,
-		"IssuerURL":  config.Tokenhandler.Dex.IssuerURL,
+		"ClientID":   config.Tokenhandler.OIDC.ClientID,
+		"IssuerURL":  config.Tokenhandler.OIDC.IssuerURL,
 		"ServerPort": config.App.Addr,
 		"KubeConfig": config.Rbachandler.KubeConfig})
 

--- a/config.toml.dist
+++ b/config.toml.dist
@@ -10,7 +10,7 @@ noColor = true
 caCertPath = "/path/to/ca.crt"
 insecure = false
 
-[tokenhandler.dex]
+[tokenhandler.oidc]
 clientID = "example-app"
 issuerURL = "http://dex/dex"
 

--- a/deploy/configmap.yaml
+++ b/deploy/configmap.yaml
@@ -6,13 +6,13 @@ metadata:
 data:
   config.yaml: |-
     app:
-      addr: ":5555" 
+      addr: ":5555"
     log:
       level: "4"
       format: "json"
       noColor: true
     tokenhandler:
-      dex:
+      oidc:
         clientID: example-app
         issuerURL: "http://dex/dex"
     rbachandler:

--- a/pkg/tokenhandler/config.go
+++ b/pkg/tokenhandler/config.go
@@ -15,7 +15,7 @@
 package tokenhandler
 
 type Config struct {
-	Dex struct {
+	OIDC struct {
 		ClientID  string
 		IssuerURL string
 	}

--- a/pkg/tokenhandler/token_handler.go
+++ b/pkg/tokenhandler/token_handler.go
@@ -26,7 +26,7 @@ import (
 	"github.com/goph/emperror"
 )
 
-// FederatedClaims dex
+// FederatedClaims oidc
 type FederatedClaims struct {
 	ConnectorID string `json:"connector_id"`
 	UserID      string `json:"user_id"`
@@ -62,18 +62,18 @@ func appendCACertPoll(config *Config) (*http.Client, error) {
 }
 
 func initProvider(config *Config) (*oidc.IDTokenVerifier, error) {
-	// Initialize a provider by specifying dex's issuer URL.
+	// Initialize a provider by specifying oidc's issuer URL.
 	httpClient, err := appendCACertPoll(config)
 	if err != nil {
 		return nil, err
 	}
 	ctx := oidc.ClientContext(context.Background(), httpClient)
-	provider, err := oidc.NewProvider(ctx, config.Dex.IssuerURL)
+	provider, err := oidc.NewProvider(ctx, config.OIDC.IssuerURL)
 	if err != nil {
-		return nil, emperror.WrapWith(err, "provider init failed", "issuerURL", config.Dex.IssuerURL)
+		return nil, emperror.WrapWith(err, "provider init failed", "issuerURL", config.OIDC.IssuerURL)
 	}
 	// Create an ID token parser, but only trust ID tokens issued to "ClientID"
-	idTokenVerifier := provider.Verifier(&oidc.Config{ClientID: config.Dex.ClientID})
+	idTokenVerifier := provider.Verifier(&oidc.Config{ClientID: config.OIDC.ClientID})
 	return idTokenVerifier, nil
 }
 


### PR DESCRIPTION
Signed-off-by: Peter Balogh <p.balogh.sa@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    |yes
| API breaks?     |yes
| Deprecations?   | no
| Related tickets | fixes #41 
| License         | Apache 2.0


### What's in this PR?
Use OIDC in the configuration.

### Why?
`jwt-to-rbac` is working with other oidc providers as well, so it will be more general if we use oidc instead of dex in configuration.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
