### PR TITLE
feat: add serviceaccount name to the response when POST the JWT token

### DIFF
--- a/internal/rbacapi/http_handler.go
+++ b/internal/rbacapi/http_handler.go
@@ -31,6 +31,14 @@ type jwtToken struct {
 	Token string `json:"token"`
 }
 
+// createRBACResponse
+type createRBACResponse struct {
+	Email           string
+	Groups          []string
+	FederatedClaims tokenhandler.FederatedClaims
+	ServiceAccount  string
+}
+
 // HTTPController collects the greeting use cases and exposes them as HTTP handlers.
 type HTTPController struct {
 	TConf  *tokenhandler.Config
@@ -90,12 +98,20 @@ func (a *HTTPController) handleRBACResources(w http.ResponseWriter, r *http.Requ
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
-		err = rbachandler.CreateRBAC(user, a.RConf, a.Logger)
+		serviceAccount, err := rbachandler.CreateRBAC(user, a.RConf, a.Logger)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
-		b, _ := json.Marshal(user)
+		a.Logger.Info("test", map[string]interface{}{
+			"test": serviceAccount.Name,
+		})
+		createRBACResponse := createRBACResponse{}
+		createRBACResponse.Email = user.Email
+		createRBACResponse.Groups = user.Groups
+		createRBACResponse.FederatedClaims = user.FederatedClaims
+		createRBACResponse.ServiceAccount = serviceAccount.Name
+		b, _ := json.Marshal(createRBACResponse)
 		w.WriteHeader(http.StatusCreated)
 		_, _ = w.Write(b)
 

--- a/pkg/rbachandler/rbac_handler_test.go
+++ b/pkg/rbachandler/rbac_handler_test.go
@@ -96,7 +96,7 @@ func TestGenerateRbacResources(t *testing.T) {
 	assert.NoError(err)
 	roleSuccess := assert.Equal(len(testRbacResources.clusterRoles), 1)
 	assert.Equal(len(testRbacResources.clusterRoleBindings), 2)
-	assert.Equal(testRbacResources.serviceAccount.name, "janedoe-example-com")
+	assert.Equal(testRbacResources.serviceAccount.Name, "janedoe-example-com")
 	if roleSuccess {
 		assert.Equal(testRbacResources.clusterRoles[0].name, "developers-from-jwt")
 	}
@@ -112,7 +112,7 @@ func TestGenerateRbacResources(t *testing.T) {
 	assert.NoError(err)
 	assert.Equal(len(testRbacResources.clusterRoles), 0)
 	assert.Equal(len(testRbacResources.clusterRoleBindings), 1)
-	assert.Equal(testRbacResources.serviceAccount.name, "janedoe-example-com")
+	assert.Equal(testRbacResources.serviceAccount.Name, "janedoe-example-com")
 	bindNames = nil
 	roleNames = nil
 	for _, crBind := range testRbacResources.clusterRoleBindings {
@@ -141,7 +141,7 @@ func TestGenerateRbacResourcesWithNameSpaces(t *testing.T) {
 	roleSuccess := assert.Equal(len(testRbacResources.clusterRoles), 1)
 	assert.Equal(len(testRbacResources.roleBindings), 1)
 	assert.Equal(len(testRbacResources.clusterRoleBindings), 1)
-	assert.Equal(testRbacResources.serviceAccount.name, "janedoe-example-com")
+	assert.Equal(testRbacResources.serviceAccount.Name, "janedoe-example-com")
 	if roleSuccess {
 		assert.Equal(testRbacResources.clusterRoles[0].name, "developers-from-jwt")
 	}
@@ -167,7 +167,7 @@ func TestGenerateRbacResourcesWithNameSpaces(t *testing.T) {
 	assert.NoError(err)
 	assert.Equal(len(testRbacResources.clusterRoles), 0)
 	assert.Equal(len(testRbacResources.clusterRoleBindings), 1)
-	assert.Equal(testRbacResources.serviceAccount.name, "janedoe-example-com")
+	assert.Equal(testRbacResources.serviceAccount.Name, "janedoe-example-com")
 	bindNames = nil
 	roleNames = nil
 	for _, crBind := range testRbacResources.clusterRoleBindings {


### PR DESCRIPTION
Signed-off-by: Peter Balogh <p.balogh.sa@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    |yes
| API breaks?     |yes
| Deprecations?   | no
| Related tickets | fixes #45 
| License         | Apache 2.0


### What's in this PR?
Add serviceaccont name to the response:
```json
{
    "Email": "test@example.com",
    "Groups": null,
    "FederatedClaims": {
        "connector_id": "github",
        "user_id": "111111111"
    },
    "ServiceAccount": "111111111"
}
```