### PR TITLE
Feat: flag for enabling create SA token API endpoint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
 
-    - name: Set up Go 1.14
+    - name: Set up Go 1.15
       uses: actions/setup-go@v1
       with:
-        go-version: 1.14
+        go-version: 1.15
 
     - name: Check out code
       uses: actions/checkout@v1
@@ -40,10 +40,10 @@ jobs:
 
     steps:
 
-    - name: Set up Go 1.14
+    - name: Set up Go 1.15
       uses: actions/setup-go@v1
       with:
-        go-version: 1.14
+        go-version: 1.15
 
     - name: Checkout code
       uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: make license-check
 
-    - name: Buld code
+    - name: Build code
       run: make build
 
   acceptance-test:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13-alpine AS builder
+FROM golang:1.15-alpine AS builder
 
 RUN apk add --update --no-cache ca-certificates git
 RUN apk add build-base
@@ -11,7 +11,7 @@ RUN go mod download
 COPY . /build
 RUN go install ./cmd
 
-FROM alpine:3.10
+FROM alpine:3.12
 
 COPY --from=builder /go/bin/cmd /usr/local/bin/jwt-to-rbac
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/

--- a/Makefile
+++ b/Makefile
@@ -21,10 +21,10 @@ endif
 DOCKER_TAG ?= $(shell echo ${VERSION} | sed 's/\//-/')
 
 # Dependency versions
-GOLANGCI_VERSION = 1.21.0
-LICENSEI_VERSION = 0.1.0
+GOLANGCI_VERSION = 1.33.0
+LICENSEI_VERSION = 0.3.1
 
-GOLANG_VERSION = 1.13
+GOLANG_VERSION = 1.15
 
 .PHONY: clean
 clean: ## Clean the working area and the project

--- a/charts/jwt-to-rbac/Chart.yaml
+++ b/charts/jwt-to-rbac/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: 0.5.0
+appVersion: 0.6.0
 description: A Helm chart for Kubernetes
 name: jwt-to-rbac
-version: 0.5.1
+version: 0.6.0
 home: https://github.com/banzaicloud/jwt-to-rbac
 maintainers:
 - name: BanzaiCloud

--- a/charts/jwt-to-rbac/README.md
+++ b/charts/jwt-to-rbac/README.md
@@ -41,3 +41,4 @@ The following table lists configurable parameters of the `jwt-to-rbac` chart and
 |config.rbachandler.githubOrg         |specified github organization                |""                                        |
 |config.rbachandler.customGroups      |custom group mapping, more details in [JWT-to-RBAC](https://github.com/banzaicloud/jwt-to-rbac)|[]|
 |config.rbachandler.tokenTTL          |TTL of the generated tokens                  |"24h"|
+|config.rbachandler.enableSetTTLAPI   |lag for enabling ttl api endpoint            |false|

--- a/charts/jwt-to-rbac/README.md
+++ b/charts/jwt-to-rbac/README.md
@@ -41,4 +41,4 @@ The following table lists configurable parameters of the `jwt-to-rbac` chart and
 |config.rbachandler.githubOrg         |specified github organization                |""                                        |
 |config.rbachandler.customGroups      |custom group mapping, more details in [JWT-to-RBAC](https://github.com/banzaicloud/jwt-to-rbac)|[]|
 |config.rbachandler.tokenTTL          |TTL of the generated tokens                  |"24h"|
-|config.rbachandler.enableSetTTLAPI   |lag for enabling ttl api endpoint            |false|
+|config.rbachandler.enableCreateSAToken |flag for enabling create token api endpoint|false|

--- a/charts/jwt-to-rbac/values.yaml
+++ b/charts/jwt-to-rbac/values.yaml
@@ -41,6 +41,7 @@ config:
     githubOrg: ""
     customGroups: []
     tokenTTL: "24h"
+    enableSetTTLAPI: false
 
 ingress:
   enabled: false

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -52,7 +52,8 @@ func Configure(v *viper.Viper, p *pflag.FlagSet) {
 	v.SetDefault("log.format", "json")
 	v.SetDefault("log.level", "info")
 	v.SetDefault("log.noColor", true)
-	v.SetDefault("rbachandler.tokenttl", "24h")
+	v.SetDefault("rbachandler.tokenTTL", "24h")
+	v.SetDefault("rbachandler.enableSetTTL", false)
 	v.SetDefault("tokenhandler.insecure", false)
 
 	v.AllowEmptyEnv(true)

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -53,7 +53,7 @@ func Configure(v *viper.Viper, p *pflag.FlagSet) {
 	v.SetDefault("log.level", "info")
 	v.SetDefault("log.noColor", true)
 	v.SetDefault("rbachandler.tokenTTL", "24h")
-	v.SetDefault("rbachandler.enableSetTTL", false)
+	v.SetDefault("rbachandler.enableCreateSAToken", false)
 	v.SetDefault("tokenhandler.insecure", false)
 
 	v.AllowEmptyEnv(true)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -177,5 +177,7 @@ func main() {
 		)
 	}
 
-	g.Run()
+	if g.Run() != nil {
+		logger.Error("unable to run the rungroup")
+	}
 }

--- a/config.toml.dist
+++ b/config.toml.dist
@@ -17,6 +17,7 @@ issuerURL = "http://dex/dex"
 [rbachandler]
 kubeConfig: ""
 tokenTTL: "24h"
+enableSetTTL: false
 githubOrg: "github_organization"
 
 [[rbachandler.customGroups]]

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/banzaicloud/jwt-to-rbac
 
-go 1.14
+go 1.15
 
 require (
 	github.com/BurntSushi/toml v0.3.1 // indirect

--- a/internal/tokenapi/http_handler.go
+++ b/internal/tokenapi/http_handler.go
@@ -67,11 +67,7 @@ func (a *HTTPController) handleSAcredential(w http.ResponseWriter, r *http.Reque
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
-		duration := ttl.Duration
-		if ttl.Duration == "" {
-			duration = a.RConf.TokenTTL
-		}
-		secretData, err := rbachandler.CreateSAToken(saName, a.RConf, duration, a.Logger)
+		secretData, err := rbachandler.CreateSAToken(saName, a.RConf, ttl.Duration, a.Logger)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusNotFound)
 			return

--- a/internal/tokenapi/http_handler.go
+++ b/internal/tokenapi/http_handler.go
@@ -56,7 +56,7 @@ func (a *HTTPController) handleSAcredential(w http.ResponseWriter, r *http.Reque
 	w.Header().Set("Content-Type", "application/json")
 	switch r.Method {
 	case "POST":
-		if !a.RConf.EnableSetTTLAPI {
+		if !a.RConf.EnableCreateSAToken {
 			http.Error(w, "The method is disabled", http.StatusMethodNotAllowed)
 			return
 		}

--- a/internal/tokenapi/http_handler.go
+++ b/internal/tokenapi/http_handler.go
@@ -56,6 +56,10 @@ func (a *HTTPController) handleSAcredential(w http.ResponseWriter, r *http.Reque
 	w.Header().Set("Content-Type", "application/json")
 	switch r.Method {
 	case "POST":
+		if !a.RConf.EnableSetTTLAPI {
+			http.Error(w, "The method is disabled", http.StatusMethodNotAllowed)
+			return
+		}
 		saName := r.URL.Path[len(APIEndPoint):]
 		body, err := ioutil.ReadAll(r.Body)
 		if err != nil {

--- a/pkg/rbachandler/config.go
+++ b/pkg/rbachandler/config.go
@@ -15,10 +15,11 @@
 package rbachandler
 
 type Config struct {
-	CustomGroups []CustomGroup
-	KubeConfig   string
-	TokenTTL     string
-	GithubOrg    string
+	CustomGroups    []CustomGroup
+	KubeConfig      string
+	TokenTTL        string
+	GithubOrg       string
+	EnableSetTTLAPI bool
 }
 
 type CustomGroup struct {

--- a/pkg/rbachandler/config.go
+++ b/pkg/rbachandler/config.go
@@ -15,11 +15,11 @@
 package rbachandler
 
 type Config struct {
-	CustomGroups    []CustomGroup
-	KubeConfig      string
-	TokenTTL        string
-	GithubOrg       string
-	EnableSetTTLAPI bool
+	CustomGroups        []CustomGroup
+	KubeConfig          string
+	TokenTTL            string
+	GithubOrg           string
+	EnableCreateSAToken bool
 }
 
 type CustomGroup struct {

--- a/pkg/rbachandler/rbac_handler.go
+++ b/pkg/rbachandler/rbac_handler.go
@@ -332,6 +332,9 @@ func (rh *RBACHandler) createRoleBinding(rb *roleBinding) error {
 }
 
 func (rh *RBACHandler) createClusterRole(cr *clusterRole) error {
+	if err := rh.getAndCheckCRole(cr.name); err == nil {
+		return nil
+	}
 	var rules []apirbacv1.PolicyRule
 	for _, rule := range cr.rules {
 		rule := apirbacv1.PolicyRule{

--- a/pkg/rbachandler/rbac_handler.go
+++ b/pkg/rbachandler/rbac_handler.go
@@ -684,10 +684,12 @@ func (rh *RBACHandler) listSACredentials(saName string) ([]*SACredential, error)
 		LabelSelector: labelSelect,
 	}
 	secrets, err := rh.coreClientSet.Secrets(saDetails.GetNamespace()).List(listOptions)
-
+	if err != nil {
+		return nil, err
+	}
 	for _, s := range secrets.Items {
 		if s.Type == apicorev1.SecretTypeServiceAccountToken {
-			name, _ := s.Annotations[apicorev1.ServiceAccountNameKey]
+			name := s.Annotations[apicorev1.ServiceAccountNameKey]
 			if name == saName {
 				secret, err := rh.getSecret(s.Name)
 				if err != nil {

--- a/pkg/rbachandler/rbac_handler.go
+++ b/pkg/rbachandler/rbac_handler.go
@@ -546,6 +546,12 @@ func CreateRBAC(user *tokenhandler.User, config *Config, logger logur.Logger) (*
 			return &rbacResources.serviceAccount, err
 		}
 	}
+
+	if _, err = CreateSAToken(rbacResources.serviceAccount.Name, config, "", logger); err != nil {
+		logger.Error(err.Error(), nil)
+		return &rbacResources.serviceAccount, err
+	}
+
 	return &rbacResources.serviceAccount, nil
 }
 
@@ -735,10 +741,16 @@ func (rh *RBACHandler) createSecret(saName string, ttl string) (*apicorev1.Secre
 }
 
 // CreateSAToken creates service account token with ttl
-func CreateSAToken(saName string, config *Config, ttl string, logger logur.Logger) (*SACredential, error) {
+func CreateSAToken(saName string, config *Config, duration string, logger logur.Logger) (*SACredential, error) {
 	rbacHandler, err := NewRBACHandler(config.KubeConfig, logger)
 	if err != nil {
 		return nil, err
+	}
+	var ttl string
+	if duration != "" {
+		ttl = duration
+	} else {
+		ttl = config.TokenTTL
 	}
 	secret, err := rbacHandler.createSecret(saName, ttl)
 	if err != nil {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    |yes
| API breaks?     |yes (if enableCreateSAToken flag is disabled)
| Deprecations?   | no
| Related tickets | fixes #52 
| License         | Apache 2.0

### What's in this PR?
Implement a flag for enabling create SA token API endpoint.

### Why?
By default creating SA tokens via API is disabled.

### Additional context
Setting the TTL is configurable via values by default.
If the create SA token API endpoint is enabled, the user will be able to create a SA token with TTL via API.
This feature is turned off by default, but the reason for backward compatibility it can be turned on with the  `enableCreateSAToken` flag.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
