### PR TITLE
Fix OwnerRefInvalidNamespace warning for RoleBindings

### DIFF
--- a/.github/workflows/charts-lint.yaml
+++ b/.github/workflows/charts-lint.yaml
@@ -3,10 +3,10 @@ on:
   pull_request:
     branches: [master]
     paths:
-      - 'charts/**'
+      - "charts/**"
+      - ".github/workflows/charts-lint.yaml"
 
 jobs:
-
   lint-test:
     runs-on: ubuntu-latest
     steps:
@@ -25,7 +25,7 @@ jobs:
           command: lint
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.0.0
+        uses: helm/kind-action@v1.2.0
         # Only build a kind cluster if there are chart changes to test.
         if: steps.lint.outputs.changed == 'true'
 

--- a/.github/workflows/charts-lint.yaml
+++ b/.github/workflows/charts-lint.yaml
@@ -26,9 +26,9 @@ jobs:
 
       - name: Create kind cluster
         uses: helm/kind-action@v1.2.0
-        # Only build a kind cluster if there are chart changes to test.
-        if: steps.lint.outputs.changed == 'true'
 
+        # Only build a kind cluster if there are chart changes to test.
+        #if: steps.lint.outputs.changed == 'true'
       - name: Run chart-testing (install)
         uses: helm/chart-testing-action@v1.0.0
         with:

--- a/.github/workflows/charts-lint.yaml
+++ b/.github/workflows/charts-lint.yaml
@@ -26,9 +26,9 @@ jobs:
 
       - name: Create kind cluster
         uses: helm/kind-action@v1.2.0
-
         # Only build a kind cluster if there are chart changes to test.
-        #if: steps.lint.outputs.changed == 'true'
+        if: steps.lint.outputs.changed == 'true'
+
       - name: Run chart-testing (install)
         uses: helm/chart-testing-action@v1.0.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,33 +3,31 @@ on:
   pull_request:
     branches: [master]
     paths-ignore:
-      - 'README.md'
-      - 'charts/**'
-      - 'docs/**'
+      - "README.md"
+      - "charts/**"
+      - "docs/**"
 
 jobs:
-
   build:
     name: Build
     runs-on: ubuntu-latest
 
     steps:
+      - name: Set up Go 1.16
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.16
 
-    - name: Set up Go 1.16
-      uses: actions/setup-go@v1
-      with:
-        go-version: 1.16
+      - name: Check out code
+        uses: actions/checkout@v1
 
-    - name: Check out code
-      uses: actions/checkout@v1
+      - name: Check licenses
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: make license-check
 
-    - name: Check licenses
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: make license-check
-
-    - name: Build code
-      run: make build
+      - name: Build code
+        run: make build
 
   acceptance-test:
     name: Acceptance test
@@ -39,28 +37,27 @@ jobs:
       VERSION: latest
 
     steps:
+      - name: Set up Go 1.16
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.16
 
-    - name: Set up Go 1.16
-      uses: actions/setup-go@v1
-      with:
-        go-version: 1.16
+      - name: Checkout code
+        uses: actions/checkout@v2
 
-    - name: Checkout code
-      uses: actions/checkout@v2
+      - name: Build Docker image
+        run: |
+          make docker
 
-    - name: Build Docker image
-      run: |
-        make docker
+      - name: Create k8s Kind Cluster
+        uses: helm/kind-action@v1.2.0
+        with:
+          cluster_name: "acceptance-test"
 
-    - name: Create k8s Kind Cluster
-      uses: helm/kind-action@v1.0.0
-      with:
-        cluster_name: "acceptance-test"
+      - name: Load Docker images to kind
+        run: |
+          kind load docker-image --name acceptance-test banzaicloud/jwt-to-rbac:latest
 
-    - name: Load Docker images to kind
-      run: |
-        kind load docker-image --name acceptance-test banzaicloud/jwt-to-rbac:latest
-
-    - name: Run make check
-      run: |
-        make check
+      - name: Run make check
+        run: |
+          make check

--- a/charts/jwt-to-rbac/Chart.yaml
+++ b/charts/jwt-to-rbac/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: 0.6.2
+appVersion: 0.6.3
 description: A Helm chart for Kubernetes
 name: jwt-to-rbac
-version: 0.6.2
+version: 0.6.3
 home: https://github.com/banzaicloud/jwt-to-rbac
 maintainers:
 - name: BanzaiCloud

--- a/pkg/rbachandler/rbac_handler.go
+++ b/pkg/rbachandler/rbac_handler.go
@@ -309,6 +309,7 @@ func (rh *RBACHandler) createRoleBinding(rb *roleBinding) error {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:   rb.name,
 				Labels: rb.labels,
+				OwnerReferences: []metav1.OwnerReference{},
 			},
 			Subjects: subjects,
 			RoleRef: apirbacv1.RoleRef{
@@ -317,12 +318,7 @@ func (rh *RBACHandler) createRoleBinding(rb *roleBinding) error {
 				Name:     rb.roleName,
 			},
 		}
-		ownerReferences, err := rh.getSAReference(rb.saName)
-		if err != nil {
-			return err
-		}
-		bindObj.SetOwnerReferences(ownerReferences)
-		_, err = rh.rbacClientSet.RoleBindings(ns).Create(bindObj)
+		_, err := rh.rbacClientSet.RoleBindings(ns).Create(bindObj)
 		if err != nil {
 			return emperror.WrapWith(err, "create rolebinding failed", "RoleBinding", rb.name)
 		}

--- a/pkg/rbachandler/rbac_handler.go
+++ b/pkg/rbachandler/rbac_handler.go
@@ -531,6 +531,7 @@ func CreateRBAC(user *tokenhandler.User, config *Config, logger logur.Logger) (*
 	}
 	if len(rbacResources.clusterRoles) > 0 {
 		for _, clusterRole := range rbacResources.clusterRoles {
+			clusterRole := clusterRole
 			if err := rbacHandler.createClusterRole(&clusterRole); err != nil {
 				logger.Error(err.Error(), nil)
 				return &rbacResources.serviceAccount, err
@@ -538,12 +539,14 @@ func CreateRBAC(user *tokenhandler.User, config *Config, logger logur.Logger) (*
 		}
 	}
 	for _, clusterRoleBinding := range rbacResources.clusterRoleBindings {
+		clusterRoleBinding := clusterRoleBinding
 		if err := rbacHandler.createClusterRoleBinding(&clusterRoleBinding); err != nil {
 			logger.Error(err.Error(), nil)
 			return &rbacResources.serviceAccount, err
 		}
 	}
 	for _, roleBinding := range rbacResources.roleBindings {
+		roleBinding := roleBinding
 		if err := rbacHandler.createRoleBinding(&roleBinding); err != nil {
 			logger.Error(err.Error(), nil)
 			return &rbacResources.serviceAccount, err

--- a/pkg/rbachandler/rbac_watcher.go
+++ b/pkg/rbachandler/rbac_watcher.go
@@ -69,6 +69,7 @@ func (rh *RBACHandler) evaluateClusterRoles(config *Config, logger logur.Logger,
 	}
 	logger.Debug("Applying custom groups rules")
 	for _, clusterRole := range rbacResources.clusterRoles {
+		clusterRole := clusterRole
 		if err := rbacHandler.createClusterRole(&clusterRole); err != nil {
 			return err
 		}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | no
| License         | Apache 2.0


### What's in this PR?

Fix OwnerRefInvalidNamespace warning when RoleBindings are referring to a Service Account that doesn't exists in the same namespace

### Why?
From Kubernetes >= 1.20 `ownerReferences` section will add the attribute `blockOwnerDeletion` to `false` as default. So when you have a warning about  `OwnerRefInvalidNamespace` the garbage collector will delete the resource, in this case the `RoleBinding` because the Service Account it's declared at another namespace.

### Additional context

```
In v1.20+, if the garbage collector detects an invalid cross-namespace ownerReference, or a cluster-scoped dependent with an ownerReference referencing a namespaced kind, a warning Event with a reason of OwnerRefInvalidNamespace and an involvedObject of the invalid dependent is reported. You can check for that kind of Event by running kubectl get events -A --field-selector=reason=OwnerRefInvalidNamespace.
```

ref: https://kubernetes.io/docs/concepts/workloads/controllers/garbage-collection/


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] Related Helm chart(s) updated (if needed)
