### PR TITLE
chore: update Go to 1.27

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Set up Go 1.26
+      - name: Set up Go 1.27
         uses: actions/setup-go@v7
         with:
-          go-version: "1.26"
+          go-version: "1.27"
 
       - name: Check out code
         uses: actions/checkout@v7
@@ -37,10 +37,10 @@ jobs:
       VERSION: latest
 
     steps:
-      - name: Set up Go 1.26
+      - name: Set up Go 1.27
         uses: actions/setup-go@v7
         with:
-          go-version: "1.26"
+          go-version: "1.27"
 
       - name: Checkout code
         uses: actions/checkout@v7

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.7-alpine AS builder
+FROM golang:1.27.0-alpine AS builder
 
 RUN apk add --update --no-cache ca-certificates git
 RUN apk add build-base

--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -1,4 +1,4 @@
-FROM golang:1.26.7-alpine AS builder
+FROM golang:1.27.0-alpine AS builder
 
 RUN apk add --update --no-cache ca-certificates git
 RUN go get github.com/derekparker/delve/cmd/dlv gcc

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ DOCKER_TAG ?= $(shell echo ${VERSION} | sed 's/\//-/')
 GOLANGCI_VERSION = 2.13.1
 LICENSEI_VERSION = 0.9.0
 
-GOLANG_VERSION = 1.26
+GOLANG_VERSION = 1.27
 
 .PHONY: clean
 clean: ## Clean the working area and the project

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/banzaicloud/jwt-to-rbac
 
-go 1.26
+go 1.27
 
 require (
 	github.com/coreos/go-oidc v2.0.0+incompatible


### PR DESCRIPTION
Bump the go directive, golang base images, Makefile version gate and CI toolchain from 1.26 to 1.27. Supersedes the open Dependabot PR #151.

